### PR TITLE
Prevent unhandled econnreset after timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ocku/whois",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A low overhead asynchronous whois client for Node.js",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/utils/__tests__/connect.test.ts
+++ b/src/utils/__tests__/connect.test.ts
@@ -4,7 +4,6 @@ import { connect } from '../connect'
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
 // vendors
-import { EventEmitter } from 'node:stream'
 import net, { NetConnectOpts } from 'node:net'
 
 describe('utils / connect', () => {
@@ -12,7 +11,7 @@ describe('utils / connect', () => {
     const mockConnect = t.mock.method(net, 'connect')
 
     mockConnect.mock.mockImplementation(() => {
-      const emitter = new EventEmitter()
+      const emitter = new net.Socket()
       setTimeout(() => emitter.emit('timeout'), 300)
       return emitter
     })

--- a/src/utils/connect.ts
+++ b/src/utils/connect.ts
@@ -9,6 +9,11 @@ export const connect = (options: net.TcpNetConnectOpts): Promise<net.Socket> =>
       resolve(socket)
     })
 
-    socket.once('timeout', () => reject(new Error('connect: timeout exceeded')))
+    socket.once('timeout', () => {
+      // Avoid ECONNRESET while reading after timeout
+      socket.destroy()
+      reject(new Error('connect: timeout exceeded'))
+    })
+
     socket.once('error', reject)
   })

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -19,7 +19,7 @@ export const query = async (
     socket.once('close', () => resolve(buffer))
     socket.on('data', (data: string) => (buffer += data))
     socket.once('timeout', () => {
-      // Avoid ECONNRESET while reading after timeout
+      // prevent ECONNRESET while reading after timeout
       socket.destroy()
       reject(new Error('query: timeout exceeded'))
     })

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -18,6 +18,10 @@ export const query = async (
     socket.write(`${message}\r\n`)
     socket.once('close', () => resolve(buffer))
     socket.on('data', (data: string) => (buffer += data))
-    socket.once('timeout', () => reject(new Error('query: timeout exceeded')))
+    socket.once('timeout', () => {
+      // Avoid ECONNRESET while reading after timeout
+      socket.destroy()
+      reject(new Error('query: timeout exceeded'))
+    })
     socket.once('error', reject)
   })


### PR DESCRIPTION
Prevent the following error after a timeout is reached:

```
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:217:20)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
```